### PR TITLE
Added Victory.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [react-d3](https://github.com/esbullington/react-d3) - Charts for React
 - [react-d3-components](https://github.com/codesuki/react-d3-components) - D3 Components for React
 - [recharts](http://recharts.org/) - Re-designed charting library built with React
+- [victory](https://github.com/FormidableLabs/victory) - A collection of composable React components for building interactive data visualizations
 
 ##### Reusable Chart Frameworks
 


### PR DESCRIPTION
Victory is one of the biggest React-specific D3 libraries. I was surprised to not see it on here.