### PR TITLE
Add swoopyDrag, an annotation layer for d3 graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [jetpack](https://github.com/gka/d3-jetpack) - Nifty convenience wrappers that speed up your daily work
 - [kodama](http://darkmarmot.github.io/kodama/) - Tooltip Plugin
 - [swoopyarrows](https://github.com/bizweekgraphics/swoopyarrows) - Plugin to create swoopy arrows with d3
+- [swoopyDrag](https://github.com/1wheel/swoopy-drag) - Artisanal label placement for d3 graphics
 - [textures](http://riccardoscalco.github.io/textures/) - SVG patterns for Data Visualization
 
 ## Miscellaneous


### PR DESCRIPTION
Related to [swoopyArrows](https://github.com/bizweekgraphics/swoopyarrows), from bizweekgraphics.