### PR TITLE
Code Editors section. Sublime and Atom snippets added

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [d3.sketchy](https://github.com/sebastian-meier/d3.sketchy) - Creates sketchy backgrounds, shapes and lines
 - [graph-scroll](http://1wheel.github.io/graph-scroll/) - Simple scrolling events for d3 graphics
 - [jsdocs2diagram](https://github.com/amcmillan01/jsdoc2diagram) - Create tree diagram from jsdoc
+
+## Code Editors
+- [D3.js snippets for Sublime Text 2](https://github.com/fabriciotav/d3-snippets-for-sublime-text-2) - D3 snippets for Sublime Text 2
+- [Atom D3 snippets](https://github.com/martgnz/d3-snippets) - An Atom package with d3 snippets

--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [jsdocs2diagram](https://github.com/amcmillan01/jsdoc2diagram) - Create tree diagram from jsdoc
 
 ## Code Editors
-- [D3.js snippets for Sublime Text 2](https://github.com/fabriciotav/d3-snippets-for-sublime-text-2) - D3 snippets for Sublime Text 2
+- [D3.js snippets for Sublime Text 2](https://github.com/fabriciotav/d3-snippets-for-sublime-text-2) - A Sublime Text 2 package with d3 snippets
 - [Atom D3 snippets](https://github.com/martgnz/d3-snippets) - An Atom package with d3 snippets


### PR DESCRIPTION
I am not sure how do you want to handle this, but I think it would be useful to have it here.

I've added two packages for Sublime and Atom. There's [another](https://github.com/shancarter/sublime-text-d3/) one for Sublime, but it's older.