### PR TITLE
Add d3-area-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [d3kit-timeline](http://kristw.github.io/d3kit-timeline/) - Timeline component that labels do not overlap
 - [d3scription](https://github.com/GlobalWebIndex/d3scription) - Tooltip with window edge collision detection
 - [d3-annotation](http://d3-annotation.susielu.com/) - Annotaion helper with built-in annotation types
+- [d3-area-label](https://github.com/curran/d3-area-label) - A library for placing labels in areas
 - [d3-component](https://github.com/curran/d3-component) - Lightweight component abstraction
 - [d3-extended](https://github.com/wbkd/d3-extended) - Extends d3 with some common jQuery functions
 - [d3-helpers](https://github.com/bahmutov/d3-helpers) - Little utility functions


### PR DESCRIPTION
A library for placing labels in areas.

[![image](https://user-images.githubusercontent.com/68416/28745722-a5d9e7a4-749b-11e7-92a8-227a56cd3ead.png)](https://bl.ocks.org/curran/2793201c7025c416c471e30d30546c6b)

You can use this to position labels on a StreamGraph or Stacked Area Chart.