### PR TITLE
Add Nivo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [d3 simplecharts](https://wordpress.org/plugins/d3-simplecharts/) - A d3 wordpress plugin
 - [ember charts](http://addepar.github.io/#/ember-charts/overview) - Charts for Ember
 - [n3-charts](http://n3-charts.github.io/line-chart/#/) - Charts for Angular
+- [nivo](https://github.com/plouc/nivo) - React dataviz components built on D3
 - [react-d3](https://github.com/esbullington/react-d3) - Charts for React
 - [react-d3-components](https://github.com/codesuki/react-d3-components) - D3 Components
 - [react-d3-library](http://react-d3-library.github.io/) - Library that allows developers the ability to use D3 in React


### PR DESCRIPTION
Just came across [Nivo](https://github.com/plouc/nivo) and noticed it was not here. It looks pretty substantial.

This is the [API documentation index](http://nivo.rocks/#/components):
![image](https://user-images.githubusercontent.com/68416/29758245-8b03b630-8bcf-11e7-980c-6e1f592a6ddd.png)
