### PR TITLE
update broken link pykcharts and add new earthjs.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [d3 geo projection](https://github.com/d3/d3-geo-projection) - Extended geographic projections
 - [d3 geomap](http://d3-geomap.github.io/) - Library for creating geographic maps
 - [d3.geo2rect](https://github.com/sebastian-meier/d3.geo2rect) - Morphing geojson polygons into rectangles
+- [earthjs.js](https://github.com/earthjs/earthjs) - Easy building orthographic globe, using D3v4 with SVG, Canvas & WebGL(Threejs) 
 - [mapmap.js](https://github.com/floledermann/mapmap.js) - A data-driven API for interactive thematic maps
 - [mapsense.js](https://github.com/mapsense/mapsense.js) - Full resolution vector maps with D3
 - [maptable](https://github.com/Packet-Clearing-House/maptable) - Convert any dataset to a customizable set of visual components (Map, Filters, Table)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Curators: [Moritz Klack](https://twitter.com/moklick) and [Christopher Möller](
 - [peek](http://mtmacdonald.github.io/peek) - Object-oriented chart library
 - [plotly](https://github.com/plotly/plotly.js/) - High level charting library
 - [plottablejs](http://plottablejs.org/) - Flexible, interactive charts for the web
-- [pykcharts](http://pykcharts.com/) - Themeable, responsive, modular, real-time charts and 109+ maps
+- [pykcharts](https://pykih.com/products/pykCharts) - Themeable, responsive, modular, real-time charts and 109+ maps
 - [radar chart](https://github.com/alangrafu/radar-chart-d3) - Radar chart module
 - [rickshaw](https://github.com/shutterstock/rickshaw) - Toolkit for creating interactive real-time graphs
 - [sankey](https://github.com/d3/d3-plugins/tree/master/sankey) - Plugin to create Sankey Diagrams


### PR DESCRIPTION
### pykcharts 
new domain: https://pykih.com/products/pykCharts 

### earthjs.js
Easy building orthographic globe, using D3v4 with SVG, Canvas & WebGL(Threejs) 
github project & some example show in these links:
* https://github.com/earthjs/earthjs
* https://earthjs.github.io/05-threejs/03-3d-globe.html
* https://earthjs.github.io/05-threejs/01-flight_2b_.html
* https://earthjs.github.io/06-3js-demo/03-small_arms_.html
 