### PR TITLE
Add d3-tribin plugin on Charts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can also explore the list with our interactive [D3 Discovery](https://d3-dis
 - [d3-flame-graph](https://github.com/spiermar/d3-flame-graph) - Flame graphs from hierarchical data
 - [d3-horizon-chart](https://github.com/kmandov/d3-horizon-chart) - Horizon charts module
 - [d3-message-sequence](https://github.com/koudelka/d3-message-sequence) - A dynamic/static message sequence chart
+- [d3-tribin](https://github.com/mfilippo/d3-tribin) - Group two-dimensional points into triangular bins [bins, triangles, sampling]
 - [d3plus](https://github.com/alexandersimoes/d3plus) - Extension library for easy creation of visualizations [scatter, stacked, line, bar, pie, network, bubble, box, map]
 - [d3-timeline](https://github.com/commodityvectors/d3-timeline) - responsive timeline charts
 - [d3fc](https://github.com/d3fc/d3fc) - A collection of interactive chart components [line, bar, stacked, scatter, candlestick, ohlc]
@@ -194,6 +195,7 @@ You can also explore the list with our interactive [D3 Discovery](https://d3-dis
  * [Ian Johnson - enjalot](https://bl.ocks.org/enjalot)
  * [Philippe Rivière - fil](https://bl.ocks.org/fil)
  * [Mike Bostock - mbostock](https://bl.ocks.org/mbostock)
+ * [Matteo Filipponi - mfilippo](https://bl.ocks.org/mfilippo)
  * [Micah Stubbs - micahstubbs](https://bl.ocks.org/micahstubbs)
  * [Nadieh Bremer - nbremer](https://bl.ocks.org/nbremer)
  * [Matteo Abrate - nitaku](https://bl.ocks.org/nitaku)


### PR DESCRIPTION
As in title, I have added a plugin (https://github.com/mfilippo/d3-tribin) to the Charts section. I also added myself (mfilippo) to the Bl.ocks.org Profiles section. :)