### PR TITLE
Add vega-lite-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can also explore the list with our interactive [D3 Discovery](https://d3-dis
 - [uvCharts](https://github.com/imaginea/uvCharts)  - Supports lots of different chart types [bar, area, pie, stacked, line, polar, donut]
 - [vega](https://github.com/vega/vega) - A visualization grammar
 - [vega-lite](https://github.com/vega/vega-lite) - A high-level grammar of interactive graphics
+- [vega-lite-api](https://github.com/vega/vega-lite-api) - A JavaScript API for Vega-Lite.
 - [venn.js](https://github.com/benfred/venn.js) - Area proportional Venn and Euler diagrams
 - [visavail](https://github.com/flrs/visavail) - Time data availability visualization
 - [vizabi](https://github.com/vizabi/vizabi) - A framework for building visual data exploration tools [bubble, map, line, bar, sankey, donut]


### PR DESCRIPTION
This is a fresh (3 month old) project coming from dataviz heavyweight Jeff Heer. It's an _even more concise_ way of generating Vega specifications. It's used in Jeff's new [Data Visualization Curriculum](https://observablehq.com/@uwdata/data-visualization-curriculum), and my gut feeling is that this library will replace direct use of `vega-lite` for many contexts going forward.